### PR TITLE
Fix Error Response Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+- Fix for double serialization on some error responses. Resulted in invalid JSON being returned.
+
 ## 0.2.2
 
 - Fix for middleware not being properly added to the pipeline

--- a/example/bin/api/errors/errors_api.dart
+++ b/example/bin/api/errors/errors_api.dart
@@ -1,14 +1,16 @@
 import 'package:dart_shelf_framework/dart_shelf_framework.dart';
 
 import 'bad_request.dart';
+import 'not_found_request.dart';
 
 final class ErrorsApi with ApiMixin {
   final BadRequest _badRequest;
-  ErrorsApi(this._badRequest);
+  final NotFoundRequest _notFoundRequest;
+  ErrorsApi(this._badRequest, this._notFoundRequest);
 
   @override
   String get prefix => '/errors';
 
   @override
-  List<ApiRouteMixin> get routes => [_badRequest];
+  List<ApiRouteMixin> get routes => [_badRequest, _notFoundRequest];
 }

--- a/example/bin/api/errors/not_found_request.dart
+++ b/example/bin/api/errors/not_found_request.dart
@@ -1,0 +1,18 @@
+import 'package:dart_shelf_framework/dart_shelf_framework.dart';
+import 'package:shelf/src/request.dart';
+import 'package:shelf/src/response.dart';
+
+/// See [ApiRouteMixin] for more information on how to handle errors.
+/// This is an example of how to issue a 404 Not Found Request response.
+final class NotFoundRequest with ApiRouteMixin {
+  @override
+  String get path => '/not-found-request';
+
+  @override
+  Future<Response> handler(Request request) async {
+    return notFound();
+  }
+
+  @override
+  HttpMethod get verb => HttpMethod.get;
+}

--- a/example/bin/server.dart
+++ b/example/bin/server.dart
@@ -4,6 +4,7 @@ import 'package:dart_shelf_framework/dart_shelf_framework.dart';
 
 import 'api/errors/bad_request.dart';
 import 'api/errors/errors_api.dart';
+import 'api/errors/not_found_request.dart';
 import 'api/logs/request_logger.dart';
 import 'api/members/members_api.dart';
 import 'api/members/routes/create.dart';
@@ -24,7 +25,7 @@ void main(List<String> args) async {
       Create(),
       GetById(),
     ),
-    ErrorsApi(BadRequest())
+    ErrorsApi(BadRequest(), NotFoundRequest())
   ];
 
   // Optional Cors Configuration.

--- a/lib/src/api/mixins/api_route_mixin.dart
+++ b/lib/src/api/mixins/api_route_mixin.dart
@@ -30,7 +30,7 @@ mixin ApiRouteMixin {
   /// with a status code of 500 Internal Server Error
   Response internalServerError(ApiResponseMixin data) {
     return Response.internalServerError(
-      body: jsonEncode(jsonEncode(data.toJson())),
+      body: jsonEncode(data.toJson()),
       headers: {'Content-Type': 'application/json'},
     );
   }
@@ -40,15 +40,13 @@ mixin ApiRouteMixin {
   /// with a status code of 404 Not Found
   Response notFound({ApiResponseMixin? data}) {
     return Response.notFound(
-      jsonEncode(
-        jsonEncode(data?.toJson() ??
-            ApiError(
-              message: 'NOT FOUND',
-              path: path,
-              statusCode: HttpStatus.notFound,
-              detail: 'NOT FOUND',
-            ).toJson()),
-      ),
+      jsonEncode(data?.toJson() ??
+          ApiError(
+            message: 'NOT FOUND',
+            path: path,
+            statusCode: HttpStatus.notFound,
+            detail: 'NOT FOUND',
+          ).toJson()),
       headers: {'Content-Type': 'application/json'},
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_shelf_framework
 description: Everything you need to build a web server with Dart.
-version: 0.2.2
+version: 0.2.3
 repository: https://github.com/strivesolutions/dart-shelf-framework
 
 environment:


### PR DESCRIPTION
## **🔧 SUMMARY OF CHANGES**
- Fixed an issue where some of the error responses were being JSON serialized twice, which resulted in them returning invalid JSON.