### PR TITLE
Improve lib import options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+- Add option to only import specific parts/features of this library. Such as only importing api related features, or only importing server related features. Left the option to import everything as well. This was to reduce the chances that types in this library would conflict with other libraries that may be used in a project.
+
 ## 0.2.3
 
 - Fix for double serialization on some error responses. Resulted in invalid JSON being returned.

--- a/example/bin/server.dart
+++ b/example/bin/server.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:dart_shelf_framework/dart_shelf_framework.dart';
-
 import 'api/errors/bad_request.dart';
 import 'api/errors/errors_api.dart';
 import 'api/errors/not_found_request.dart';

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.2.3"
   http:
     dependency: "direct dev"
     description:

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -1,0 +1,14 @@
+/// Dart Shelf Framework
+///
+/// A framework for building REST APIs using Dart and Shelf.
+library;
+
+export 'src/api/api_response.dart';
+export 'src/api/api_error.dart';
+export 'src/api/http_method.dart';
+export 'src/api/type_definitions.dart';
+
+export 'src/api/mixins/api_error_mixin.dart';
+export 'src/api/mixins/api_response_mixin.dart';
+export 'src/api/mixins/api_mixin.dart';
+export 'src/api/mixins/api_route_mixin.dart';

--- a/lib/serialization.dart
+++ b/lib/serialization.dart
@@ -1,0 +1,7 @@
+/// Dart Shelf Framework
+///
+/// A framework for building REST APIs using Dart and Shelf.
+library;
+
+export 'src/serialization/serializable.dart';
+export 'src/serialization/serialization_extensions.dart';

--- a/lib/server.dart
+++ b/lib/server.dart
@@ -1,0 +1,10 @@
+/// Dart Shelf Framework
+///
+/// A framework for building REST APIs using Dart and Shelf.
+library;
+
+export 'src/server/router_factory.dart';
+export 'src/server/server_builder.dart';
+export 'src/server/cors_config.dart';
+
+export 'src/server/mixins/server_mixin.dart';

--- a/lib/src/server/cors_config.dart
+++ b/lib/src/server/cors_config.dart
@@ -1,4 +1,4 @@
-import 'package:dart_shelf_framework/src/server/type_definitions.dart';
+import 'package:shelf/shelf.dart';
 import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 
 /// Configuration for CORS Middleware

--- a/lib/src/server/server_builder.dart
+++ b/lib/src/server/server_builder.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dart_shelf_framework/dart_shelf_framework.dart';
 import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart';
 
 /// Fluent API for building a server.

--- a/lib/src/server/type_definitions.dart
+++ b/lib/src/server/type_definitions.dart
@@ -2,9 +2,6 @@ import 'dart:async';
 import 'package:shelf/shelf.dart';
 
 /// Type definitions for the server.
-typedef Middleware = FutureOr<Response> Function(Request) Function(
-    FutureOr<Response> Function(Request));
-
 typedef RequestHandler = FutureOr<Response> Function(Request);
 
 typedef Logger = void Function(String message, bool isError);

--- a/lib/type_definitions.dart
+++ b/lib/type_definitions.dart
@@ -1,0 +1,6 @@
+/// Dart Shelf Framework
+///
+/// A framework for building REST APIs using Dart and Shelf.
+library;
+
+export 'src/server/type_definitions.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_shelf_framework
 description: Everything you need to build a web server with Dart.
-version: 0.2.3
+version: 0.2.4
 repository: https://github.com/strivesolutions/dart-shelf-framework
 
 environment:


### PR DESCRIPTION
## **🔧 SUMMARY OF CHANGES**
- Add option to only import specific parts/features of this library. Such as only importing api related features, or only importing server related features. Left the option to import everything as well. This was to reduce the chances that types in this library would conflict with other libraries that may be used in a project.