### PR TITLE
Option to disable default request logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+
+- Added new ServerBuilder option to completely disable request logging. This is useful if you want full control of the logging middleware. You can then add your own logging middleware to the pipeline by calling `addMiddleware` on the `ServerBuilder` instance.
+
 ## 0.2.4
 
 - Add option to only import specific parts/features of this library. Such as only importing api related features, or only importing server related features. Left the option to import everything as well. This was to reduce the chances that types in this library would conflict with other libraries that may be used in a project.

--- a/lib/src/server/server_builder.dart
+++ b/lib/src/server/server_builder.dart
@@ -13,6 +13,7 @@ final class ServerBuilder {
   final List<ApiMixin> apis = [];
   final String basePath;
   bool autoCompressContent = false;
+  bool useDefaultLogger = true;
   Logger? logger;
 
   ServerBuilder({
@@ -66,6 +67,14 @@ final class ServerBuilder {
     return this;
   }
 
+  /// Disables the default logger for the server.
+  /// Useful if you want to use a custom logger.
+  /// This setting is ignored if [addRequestLogger] is called.
+  ServerBuilder disableDefaultLogger() {
+    useDefaultLogger = false;
+    return this;
+  }
+
   /// Starts the server.
   Future<HttpServer> start() async {
     final router = RouterFactory.create(apis, routerBasePath: basePath);
@@ -90,7 +99,9 @@ final class ServerBuilder {
       pipeline = pipeline.addMiddleware(middleware);
     }
 
-    pipeline = pipeline.addMiddleware(shelf.logRequests(logger: logger));
+    if (useDefaultLogger || logger != null) {
+      pipeline = pipeline.addMiddleware(shelf.logRequests(logger: logger));
+    }
 
     return pipeline;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_shelf_framework
 description: Everything you need to build a web server with Dart.
-version: 0.2.4
+version: 0.2.5
 repository: https://github.com/strivesolutions/dart-shelf-framework
 
 environment:


### PR DESCRIPTION
## **🔧 SUMMARY OF CHANGES**
- Added new ServerBuilder option to completely disable request logging. This is useful if you want full control of the logging middleware. You can then add your own logging middleware to the pipeline by calling `addMiddleware` on the `ServerBuilder` instance.